### PR TITLE
Changed deprecated getUserMedia to use mediaDevices

### DIFF
--- a/src/webgazer.js
+++ b/src/webgazer.js
@@ -394,7 +394,7 @@
         console.log(videoElement);
         videoElement.style.display = 'none';
 
-        // set the source of the stream
+        // set the video source as the stream
         if ("srcObject" in videoElement) {
           videoElement.srcObject = videoStream;
         } else {
@@ -425,7 +425,7 @@
      * Initializes navigator.mediaDevices.getUserMedia
      * depending on the browser capabilities
      */
-    function setGetUserMedia(){
+    function setUserMediaVariable(){
 
       if (navigator.mediaDevices === undefined) {
         navigator.mediaDevices = {};
@@ -461,7 +461,7 @@
     webgazer.begin = function(onFail) {
         loadGlobalData();
 
-        onFail = onFail || function(error) {console.log('No stream')};
+        onFail = onFail || function() {console.log('No stream')};
 
         if (debugVideoLoc) {
             init(debugVideoLoc);
@@ -472,7 +472,7 @@
         var options = webgazer.params.camConstraints;
 
         // sets .mediaDevices.getUserMedia depending on browser
-        setGetUserMedia();
+        setUserMediaVariable();
 
         // request webcam access
         navigator.mediaDevices.getUserMedia(options)

--- a/src/webgazer.js
+++ b/src/webgazer.js
@@ -385,21 +385,21 @@
 
     /**
      * Initializ es all needed dom elements and begins the loop
-     * @param {URL} videoSrc - The video url to use
+     * @param {URL} videoStream - The video stream to use
      */
-    function init(videoSrc) {
+    function init(videoStream) {
         videoElement = document.createElement('video');
         videoElement.id = webgazer.params.videoElementId;
         videoElement.autoplay = true;
         console.log(videoElement);
         videoElement.style.display = 'none';
 
-        // set the source as the video
+        // set the source of the stream
         if ("srcObject" in videoElement) {
-          videoElement.srcObject = videoSrc;
+          videoElement.srcObject = videoStream;
         } else {
-          // Avoid using this in new browsers, as it is going away.
-          videoElement.src = window.URL.createObjectURL(videoSrc);
+          // used for older browsers
+          videoElement.src = window.URL.createObjectURL(videoStream);
         }
 
         document.body.appendChild(videoElement);


### PR DESCRIPTION
navigator.getUserMedia now uses navigator.mediaDevices.getUserMedia.

This was tested with:

- Google Chrome
- Safari 11