### PR TITLE
Moved browser-sync dependencies

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -5,9 +5,11 @@
     "type": "git",
     "url": "https://github.com/brownhci/WebGazer.git"
   },
+  "devDependencies": {
+    "browser-sync": "^2.24.4"
+  },
   "dependencies": {
     "bootstrap": "^3.3.6",
-    "browser-sync": "^2.24.4",
     "d3": "3.5.9",
     "jquery": "1.12.4",
     "sweetalert": "^2.1.0"


### PR DESCRIPTION
Now that I think about it, when node is deployed on the server browser-sync probably shouldn't be downloaded, only during development. Thoughts? @Libby713 @Jack-Wong94 