### PR TITLE
Updated JQuery and Bootstrap versions and styled header

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -25,6 +25,10 @@ body {
     padding-top: 70px;
 }
 
+.jumbotron {
+    background-color:transparent !important;
+}
+
 .padright {
     padding-top: 0px;
     margin-bottom: 22px;

--- a/www/package.json
+++ b/www/package.json
@@ -6,10 +6,10 @@
     "url": "https://github.com/brownhci/WebGazer.git"
   },
   "dependencies": {
-    "bootstrap": "^3.3.6",
+    "bootstrap": "^3.3.7",
     "browser-sync": "^2.24.4",
     "d3": "3.5.9",
-    "jquery": "1.12.4",
+    "jquery": "^3.0.0",
     "sweetalert": "^2.1.0"
   }
 }


### PR DESCRIPTION
Due to a potential vulnerability, JQuery and Bootstrap have been updated to versions 3.x and 3.3.7 respectively.

The jumbotron default background colour changed to grey, so I've changed this back to transparent.